### PR TITLE
Update utils.ts to fix bug when character is a single char

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,7 +71,7 @@ export const getCharactersData = ({
   let step = 0
 
   const getRevealTime = (isIgnored: boolean): number => {
-    if (isIgnored || revealDuration === 0) {
+    if (isIgnored || revealDuration === 0 || charactersArray.length === 1) {
       return duration
     }
 


### PR DESCRIPTION
when "character "is set to a single character then revealTime divides by 0 and is not a number so it will always reveal a random character and not the character set